### PR TITLE
Workaround for joblib update breaking hdbscan

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+joblib==1.1.0
 top2vec==1.0.26
 gensim==3.8.3
 streamlit==1.2.0


### PR DESCRIPTION
https://github.com/scikit-learn-contrib/hdbscan/issues/565 https://stackoverflow.com/questions/73830225/init-got-an-unexpected-keyword-argument-cachedir-when-importing-top2vec